### PR TITLE
Update homepage to repository in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 description = "Convert a CSV to parquet file format"
 authors = ["rayyildiz"]
 license-file = "LICENSE"
-homepage = "https://github.com/rayyildiz/cc2p"
+repository = "https://github.com/rayyildiz/cc2p"
 readme = "README.md"
 
 [dependencies]


### PR DESCRIPTION
Change `homepage` key to instead use the [repository](https://rust-digger.code-maven.com/about-repository) key for correctly labeling/pointing to the GitHub repo.

This makes location of the source code easier to see Crates.io. 🙂